### PR TITLE
Add option to configure a custom base url based on wakapi.

### DIFF
--- a/custom_components/wakatime/__init__.py
+++ b/custom_components/wakatime/__init__.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api import WakatimeApiClient
-from .const import DOMAIN, SCAN_INTERVAL
+from .const import DOMAIN, SCAN_INTERVAL, CONF_BASE_URL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,9 +25,9 @@ PLATFORMS = [Platform.SENSOR]
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Wakatime from a config entry."""
     api_key = entry.data[CONF_API_KEY]
-
+    base_url = user_input.get(CONF_BASE_URL, "https://wakatime.com/api/v1")
     session = async_get_clientsession(hass)
-    client = WakatimeApiClient(api_key, session)
+    client = WakatimeApiClient(api_key, session, base_url=base_url)
 
     coordinator = WakatimeDataUpdateCoordinator(hass, client=client)
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/wakatime/__init__.py
+++ b/custom_components/wakatime/__init__.py
@@ -25,7 +25,7 @@ PLATFORMS = [Platform.SENSOR]
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Wakatime from a config entry."""
     api_key = entry.data[CONF_API_KEY]
-    base_url = user_input.get(CONF_BASE_URL, "https://wakatime.com/api/v1")
+    base_url = entry.data.get(CONF_BASE_URL, "https://wakatime.com/api/v1")
     session = async_get_clientsession(hass)
     client = WakatimeApiClient(api_key, session, base_url=base_url)
 

--- a/custom_components/wakatime/api.py
+++ b/custom_components/wakatime/api.py
@@ -13,19 +13,24 @@ import base64
 class WakatimeApiClient:
     """API client for Wakatime."""
 
-    def __init__(self, api_key: str, session: aiohttp.ClientSession,
-                 base_url: str = "https://wakatime.com/api/v1") -> None:
-        """Initialize the API client."""
+    def _prepare_auth_and_url(self, api_key: str, base_url: str) -> tuple[str, str]:
+        """Prepare authentication and URL for different API providers."""
         if "wakatime.com" not in base_url:
-            # needs to be base64 encoded to work
-            b = base64.b64encode(bytes(api_key, 'utf-8'))  # bytes
-            api_key = b.decode('utf-8')  # convert bytes to
-            # endpoints differ a little bit
+            # Wakapi needs base64 encoded API key
+            b = base64.b64encode(bytes(api_key, 'utf-8'))
+            api_key = b.decode('utf-8')
+            # Wakapi endpoints differ from Wakatime
             if "compat/wakatime" not in base_url:
                 base_url += "/compat/wakatime/v1"
         if base_url.endswith("/"):
             # avoid // in url
             base_url = base_url[:-1]
+        return api_key, base_url
+
+    def __init__(self, api_key: str, session: aiohttp.ClientSession,
+                 base_url: str = "https://wakatime.com/api/v1") -> None:
+        """Initialize the API client."""
+        api_key, base_url = self._prepare_auth_and_url(api_key, base_url)
         self._api_key = api_key
         self._session = session
         self._headers = {"Authorization": f"Basic {api_key}"}

--- a/custom_components/wakatime/api.py
+++ b/custom_components/wakatime/api.py
@@ -7,21 +7,19 @@ import aiohttp
 
 _LOGGER = logging.getLogger(__name__)
 
-BASE_URL = "https://wakatime.com/api/v1"
-
-
 class WakatimeApiClient:
     """API client for Wakatime."""
 
-    def __init__(self, api_key: str, session: aiohttp.ClientSession) -> None:
+    def __init__(self, api_key: str, session: aiohttp.ClientSession, base_url:str="https://wakatime.com/api/v1") -> None:
         """Initialize the API client."""
         self._api_key = api_key
         self._session = session
         self._headers = {"Authorization": f"Basic {api_key}"}
+        self._base_url = base_url
 
     async def _fetch_data(self, endpoint: str) -> dict:
         """Fetch data from the API."""
-        url = f"{BASE_URL}/{endpoint}"
+        url = f"{self._base_url}/{endpoint}"
 
         async with self._session.get(url, headers=self._headers) as response:
             if response.status != 200:

--- a/custom_components/wakatime/api.py
+++ b/custom_components/wakatime/api.py
@@ -22,7 +22,7 @@ class WakatimeApiClient:
             api_key = b.decode('utf-8')  # convert bytes to
             # endpoints differ a little bit
             if "compat/wakatime" not in base_url:
-                base_url += "/compat/wakatime/api/v1"
+                base_url += "/compat/wakatime/v1"
         if base_url.endswith("/"):
             # avoid // in url
             base_url = base_url[:-1]

--- a/custom_components/wakatime/api.py
+++ b/custom_components/wakatime/api.py
@@ -34,8 +34,6 @@ class WakatimeApiClient:
     async def _fetch_data(self, endpoint: str) -> dict:
         """Fetch data from the API."""
         url = f"{self._base_url}/{endpoint}"
-        print("url", url)
-        print("headers", self._headers)
         async with self._session.get(url, headers=self._headers) as response:
             if response.status != 200:
                 _LOGGER.error(

--- a/custom_components/wakatime/api.py
+++ b/custom_components/wakatime/api.py
@@ -39,7 +39,7 @@ class WakatimeApiClient:
         async with self._session.get(url, headers=self._headers) as response:
             if response.status != 200:
                 _LOGGER.error(
-                    "Error fetching data from Wakatime API: %s", response.status
+                    "Error fetching data from Wakatime API: %s, %s", response.status, url
                 )
                 return {}
 

--- a/custom_components/wakatime/config_flow.py
+++ b/custom_components/wakatime/config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .api import WakatimeApiClient
-from .const import DOMAIN, NAME
+from .const import DOMAIN, NAME, CONF_BASE_URL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,9 +29,10 @@ class WakatimeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
+            base_url = user_input.get(CONF_BASE_URL, "https://wakatime.com/api/v1")
             api_key = user_input[CONF_API_KEY]
             session = async_get_clientsession(self.hass)
-            client = WakatimeApiClient(api_key, session)
+            client = WakatimeApiClient(api_key, session, base_url=base_url)
 
             try:
                 user_info = await client.get_user_info()
@@ -54,6 +55,7 @@ class WakatimeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_API_KEY): str,
+                    vol.Optional(CONF_BASE_URL, default="https://wakatime.com/api/v1"): str,
                 }
             ),
             errors=errors,

--- a/custom_components/wakatime/const.py
+++ b/custom_components/wakatime/const.py
@@ -7,6 +7,7 @@ LOGGER: Logger = getLogger(__package__)
 DOMAIN = "wakatime"
 NAME = "Wakatime"
 SCAN_INTERVAL = 30  # Minutes
+DEFAULT_BASE_URL = "https://wakatime.com/api/v1"
 
 # Icons
 ICON_CODING = "mdi:code-braces"

--- a/custom_components/wakatime/const.py
+++ b/custom_components/wakatime/const.py
@@ -7,7 +7,6 @@ LOGGER: Logger = getLogger(__package__)
 DOMAIN = "wakatime"
 NAME = "Wakatime"
 SCAN_INTERVAL = 30  # Minutes
-DEFAULT_BASE_URL = "https://wakatime.com/api/v1"
 
 # Icons
 ICON_CODING = "mdi:code-braces"

--- a/custom_components/wakatime/const.py
+++ b/custom_components/wakatime/const.py
@@ -22,3 +22,5 @@ ICON_WEEKLY = "mdi:calendar-week"
 ICON_PRODUCTIVITY = "mdi:trending-up"
 ICON_ACTIVE_TIME = "mdi:clock-time-eight"
 ICON_STREAK = "mdi:fire"
+
+CONF_BASE_URL = "base_url"


### PR DESCRIPTION
### Context

I am self-hosting [Wakapi](https://github.com/muety/wakapi), which is fully compatible with WakaTime's API but introduces some differences, notably in endpoint naming conventions. As a result, I am using a custom base URL to interact with my Wakapi instance.

### Key Differences

- **Endpoint Naming**: While Wakapi aims for compatibility with WakaTime, some API endpoints are named differently.  
- **Authentication**: Unlike the WakaTime API, Wakapi requires authentication credentials to be provided as a Base64-encoded string, rather than in the standard format. 

### Enhancement

This PR addresses these differences by:
- Allowing a configurable base URL for API requests, enabling support for self-hosted Wakapi instances.
- Adjusting authentication handling to support Base64-encoded credentials as required by Wakapi.

<img width="421" height="808" alt="image" src="https://github.com/user-attachments/assets/691aa914-f77e-4f13-8636-6a9d6dea1fc4" />

<img width="598" height="547" alt="image" src="https://github.com/user-attachments/assets/b4c670f2-e19b-45b6-9eae-080c8e24ff5a" />



Thank you for the initial development!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a custom base URL for the Wakatime integration, allowing connection to alternative or self-hosted Wakatime API endpoints.

* **Enhancements**
  * Improved error logging to include full request URLs and HTTP status codes for easier troubleshooting during API requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->